### PR TITLE
fix(infra): adding default node roles to service account

### DIFF
--- a/infrastructure/cluster/data.tf
+++ b/infrastructure/cluster/data.tf
@@ -1,1 +1,11 @@
 data "google_client_openid_userinfo" "me" {}
+
+data "google_iam_policy" "default_node" {
+  binding {
+    role = "roles/container.defaultNodeServiceAccount"
+
+    members = [
+      "serviceAccount:${google_service_account.nodes.email}",
+    ]
+  }
+}

--- a/infrastructure/cluster/main.tf
+++ b/infrastructure/cluster/main.tf
@@ -3,6 +3,11 @@ resource "google_service_account" "nodes" {
   display_name = var.pool_service_account_name
 }
 
+resource "google_service_account_iam_policy" "default_node" {
+  service_account_id = google_service_account.nodes.name
+  policy_data        = data.google_iam_policy.default_node.policy_data
+}
+
 resource "google_service_account_iam_member" "grant_sa_user" {
   service_account_id = google_service_account.nodes.name
   role               = "roles/iam.serviceAccountUser"


### PR DESCRIPTION
See [here](https://cloud.google.com/kubernetes-engine/docs/how-to/service-accounts#default-gke-service-agent) for background