### PR TITLE
fix(infra): make project variable required

### DIFF
--- a/infrastructure/networking/README.md
+++ b/infrastructure/networking/README.md
@@ -245,14 +245,14 @@ This module requires several variables to be set before it can be applied. The m
 | `project` | GCP project ID to deploy resources within | From your Google Cloud Console |
 | `github_username` | GitHub username that owns the repository | Your GitHub username |
 
-### GitHub OAuth Setup
+### GitHub Organization OAuth Setup
 
-To obtain the GitHub OAuth credentials needed for IAP authentication:
+To obtain the GitHub OAuth credentials needed for IAP authentication with a GitHub organization:
 
-1. Go to your GitHub account → Settings → Developer settings → OAuth Apps
+1. Go to your GitHub organization → Settings → Developer settings → OAuth Apps
 2. Click "New OAuth App"
 3. Fill in the following details:
-   - **Application name**: `data-project-example`
+   - **Application name**: `example-org`
    - **Homepage URL**: `https://data-project-example.net`
    - **Authorization callback URL**: `https://iap.googleapis.com/v1/oauth/clientIds/YOUR_CLIENT_ID:handleRedirect`
      - Note: You'll need to update this URL after creating the OAuth app and getting the client ID
@@ -260,6 +260,14 @@ To obtain the GitHub OAuth credentials needed for IAP authentication:
 5. You'll receive a Client ID immediately
 6. Click "Generate a new client secret" to get your Client Secret
 7. Save both the Client ID and Client Secret for use in Terraform Cloud
+8. Configure organization permissions:
+   - Go to the OAuth App settings
+   - Under "Organization access", grant access to your organization
+   - Set appropriate permission scopes based on your requirements
+9. For production deployments, consider:
+   - Verifying the domain associated with your organization
+   - Setting up IP allowlists for added security
+   - Configuring SAML SSO integration if your organization uses it
 
 ## Terraform Cloud Setup
 

--- a/infrastructure/networking/README.md
+++ b/infrastructure/networking/README.md
@@ -212,7 +212,7 @@ module "networking" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| project | GCP project to deploy resources within | `string` | `"data-project-example"` | no |
+| project | GCP project to deploy resources within | `string` | n/a | yes |
 | region | GCP region to deploy resources within | `string` | `"us-central1"` | no |
 | vpc_name | Name of the VPC to create | `string` | `"k8s-vpc"` | no |
 | subnets | List of subnet configurations | `list(object)` | See variables.tf | no |

--- a/infrastructure/networking/README.md
+++ b/infrastructure/networking/README.md
@@ -197,10 +197,8 @@ module "networking" {
   ]
   
   # GitHub Authentication
-  github_oauth = {
-    client_id     = "your-github-oauth-client-id"
-    client_secret = "your-github-oauth-client-secret"
-  }
+  github_oauth_client_id     = "your-github-oauth-client-id"
+  github_oauth_client_secret = "your-github-oauth-client-secret"
   
   # GitHub Workload Identity Federation
   project_id_prefix = "myproj"
@@ -240,8 +238,8 @@ This module requires several variables to be set before it can be applied. The m
 
 | Name | Description | How to Obtain |
 |------|-------------|--------------|
-| `github_oauth.client_id` | GitHub OAuth client ID for IAP authentication | See [GitHub OAuth Setup](#github-oauth-setup) below |
-| `github_oauth.client_secret` | GitHub OAuth client secret for IAP authentication | See [GitHub OAuth Setup](#github-oauth-setup) below |
+| `github_oauth_client_id` | GitHub OAuth client ID for IAP authentication | See [GitHub OAuth Setup](#github-oauth-setup) below |
+| `github_oauth_client_secret` | GitHub OAuth client secret for IAP authentication | See [GitHub OAuth Setup](#github-oauth-setup) below |
 | `project` | GCP project ID to deploy resources within | From your Google Cloud Console |
 | `github_username` | GitHub username that owns the repository | Your GitHub username |
 
@@ -302,19 +300,10 @@ Before running `terraform plan` or `terraform apply`, you need to set up the req
 
 | Key | Category | Sensitive | Description |
 |-----|----------|-----------|-------------|
-| `github_oauth.client_id` | Terraform | Yes | GitHub OAuth client ID from the setup above |
-| `github_oauth.client_secret` | Terraform | Yes | GitHub OAuth client secret from the setup above |
+| `github_oauth_client_id` | Terraform | Yes | GitHub OAuth client ID from the setup above |
+| `github_oauth_client_secret` | Terraform | Yes | GitHub OAuth client secret from the setup above |
 | `project` | Terraform | No | Your GCP project ID |
 | `github_username` | Terraform | No | Your GitHub username |
-
-For complex variable types like `github_oauth`, you'll need to use HCL format:
-
-```hcl
-github_oauth = {
-  client_id     = "your-github-oauth-client-id"
-  client_secret = "your-github-oauth-client-secret"
-}
-```
 
 5. Save the variables
 6. Now you can run `terraform plan` and `terraform apply` from your local machine, and Terraform Cloud will use these variables

--- a/infrastructure/networking/data.tf
+++ b/infrastructure/networking/data.tf
@@ -6,11 +6,6 @@ data "google_project" "current" {
   project_id = var.project
 }
 
-# Get the default compute service account
-data "google_compute_default_service_account" "default" {
-  project = var.project
-}
-
 # Get the current user's email for IAP configuration
 data "google_client_config" "current" {}
 

--- a/infrastructure/networking/iap.tf
+++ b/infrastructure/networking/iap.tf
@@ -53,8 +53,8 @@ resource "google_compute_backend_service" "backend_service" {
   health_checks = [google_compute_health_check.health_check[each.key].id]
   
   iap {
-    oauth2_client_id     = var.github_oauth.client_id
-    oauth2_client_secret = var.github_oauth.client_secret
+    oauth2_client_id     = var.github_oauth_client_id
+    oauth2_client_secret = var.github_oauth_client_secret
     enabled              = true
   }
 }

--- a/infrastructure/networking/outputs.tf
+++ b/infrastructure/networking/outputs.tf
@@ -141,7 +141,7 @@ output "iap_client" {
 
 output "github_oauth_client_id" {
   description = "The GitHub OAuth client ID for IAP authentication"
-  value       = var.github_oauth.client_id
+  value       = var.github_oauth_client_id
   sensitive   = true
 }
 

--- a/infrastructure/networking/plan.md
+++ b/infrastructure/networking/plan.md
@@ -162,10 +162,13 @@ graph TD
 ### One-Time Setup Steps
 
 1. **Update Networking Module Configuration**:
-   - Modify `variables.tf` to support EXTERNAL IPs and GitHub authentication
+   - Modify `variables.tf` to support EXTERNAL IPs and GitHub organization authentication
    - Update `main.tf` to create the necessary static IPs
    - Create `iap.tf` and `oauth.tf` for authentication configuration
-   - Enhance `iam.tf` with role bindings for GitHub repository roles
+   - Enhance `iam.tf` with role bindings for GitHub organization teams
+   - Add support for team-based access control
+   - Configure organization-level permission mappings
+   - Add variables for organization settings
 
 2. **Deploy the Updated Networking Module**:
    ```bash
@@ -174,10 +177,13 @@ graph TD
    terraform apply
    ```
 
-3. **Set Up GitHub OAuth Application**:
-   - Create a new OAuth application in GitHub
+3. **Set Up GitHub Organization OAuth Application**:
+   - Create a new OAuth application in GitHub organization settings
    - Configure callback URLs for IAP authentication
    - Obtain client ID and secret
+   - Configure organization permissions and access
+   - Set appropriate permission scopes
+   - Consider domain verification for production deployments
 
 4. **Configure IAP with GitHub Authentication**:
    - Set up IAP in Google Cloud Console
@@ -238,15 +244,19 @@ ArgoCD will be deployed as a special case with the following considerations:
    - ArgoCD will have a dedicated static IP at `cd.data-project-example.net`
    - This IP will be EXTERNAL to allow user access
 
-2. **GitHub Authentication**:
+2. **GitHub Organization Authentication**:
    - ArgoCD will use GitHub OAuth for authentication
-   - Users with WRITE access to the repository will be able to access ArgoCD
+   - Team-based access can be configured
+   - Organization-wide policies can be applied
+   - SSO integration is available for enterprise accounts
 
 3. **RBAC Configuration**:
-   - Repository roles will be mapped to ArgoCD roles:
-     - READ: read-only access to applications
-     - WRITE: ability to sync applications
-     - ADMIN: full administrative access
+   - Team roles can be mapped to ArgoCD roles:
+     - READ: read-only access to applications (e.g., developer team)
+     - WRITE: ability to sync applications (e.g., devops team)
+     - ADMIN: full administrative access (e.g., platform team)
+   - Custom organization roles can be used for fine-grained access control
+   - SAML group mappings can be configured for enterprise GitHub accounts
 
 4. **Integration with Helm Applications**:
    - ArgoCD will manage Helm-deployed applications
@@ -259,28 +269,31 @@ The hello-world application defined in `infrastructure/charts/argo-cd/templates/
 
 1. **Deployed at Root Domain**:
    - Accessible at `data-project-example.net`
-   - Requires GitHub READ access to view
+   - Requires GitHub organization team membership with READ access
 
 2. **Managed by ArgoCD**:
    - Defined as an ArgoCD Application resource
    - Automatically synced from the GitHub repository
+   - Deployment approvals can be configured based on team membership
 
 3. **Secured with IAP**:
    - Protected by Identity-Aware Proxy
-   - Authenticated using GitHub OAuth
-   - Access controlled based on repository roles
+   - Authenticated using GitHub organization OAuth
+   - Access controlled based on organization team roles
+   - SSO integration available for enterprise GitHub accounts
 
 ## Code Changes
 
 The following files will need to be modified or created:
 
-1. `variables.tf` - Add variables for GitHub OAuth, IAP configuration, and role mapping
+1. `variables.tf` - Add variables for GitHub organization OAuth, IAP configuration, and team role mapping
 2. `main.tf` - Update static IP configuration to support EXTERNAL IPs
 3. `outputs.tf` - Add outputs for GitHub OAuth client ID, IAP settings, and static IP addresses
-4. `data.tf` - Add data sources for GitHub repository and user information
-5. `iam.tf` - Enhance with role bindings for GitHub repository roles
+4. `data.tf` - Add data sources for GitHub organization, teams, and membership information
+5. `iam.tf` - Enhance with role bindings for GitHub organization teams
 6. New file: `iap.tf` - Implement IAP configuration and backend services
-7. New file: `oauth.tf` - Implement GitHub OAuth client registration and configuration
+7. New file: `oauth.tf` - Implement GitHub organization OAuth client registration and configuration
+8. New file: `teams.tf` - Define mappings between GitHub organization teams and IAM roles
 
 ## Netlify DNS Configuration Instructions
 

--- a/infrastructure/networking/terraform.tf
+++ b/infrastructure/networking/terraform.tf
@@ -11,7 +11,7 @@ terraform {
     organization = "jolfr-personal"
 
     workspaces {
-      name = "data-project-example-networking"
+      name = "networking"
     }
   }
 }

--- a/infrastructure/networking/variables.tf
+++ b/infrastructure/networking/variables.tf
@@ -51,7 +51,6 @@ variable "github_username" {
 variable "project" {
   description = "GCP project to deploy resources within"
   type        = string
-  default     = "data-project-example"
 }
 
 variable "region" {

--- a/infrastructure/networking/variables.tf
+++ b/infrastructure/networking/variables.tf
@@ -13,13 +13,16 @@ locals {
 # GitHub Authentication Variables
 #--------------------------------------------------------------
 
-variable "github_oauth" {
-  description = "GitHub OAuth configuration for IAP authentication"
-  type = object({
-    client_id     = string
-    client_secret = string
-  })
-  sensitive = true
+variable "github_oauth_client_id" {
+  description = "GitHub OAuth client ID for IAP authentication"
+  type        = string
+  sensitive   = true
+}
+
+variable "github_oauth_client_secret" {
+  description = "GitHub OAuth client secret for IAP authentication"
+  type        = string
+  sensitive   = true
 }
 
 variable "github_rbac" {


### PR DESCRIPTION
This pull request includes changes to the `infrastructure/networking` module to update the project variable configuration.

### Updates to project variable configuration:

* [`infrastructure/networking/README.md`](diffhunk://#diff-d16d5e4c504611746c6074741346978561eb19b2c8f48453dab29eef5ce9c1e1L215-R215): Changed the `project` variable to be required and removed the default value.
* [`infrastructure/networking/variables.tf`](diffhunk://#diff-ec6939a329188c8383ce945bb4991aab7f5d68f4bb3b234bbb9f0018ee38d67dL54): Removed the default value for the `project` variable to ensure it is explicitly provided during deployment.