### PR TITLE
docs(infra): update documentation with required IAM policies

### DIFF
--- a/infrastructure/networking/setup.md
+++ b/infrastructure/networking/setup.md
@@ -59,9 +59,13 @@ The account running Terraform needs the following permissions:
 
 1. `roles/iam.workloadIdentityPoolAdmin` - To create and manage Workload Identity Pools
 2. `roles/iam.serviceAccountAdmin` - To create and manage service accounts
-3. `roles/compute.networkAdmin` - To create and manage network resources
-4. `roles/compute.securityAdmin` - To create and manage firewall rules
-5. `roles/iap.admin` - To configure Identity-Aware Proxy
+3. `roles/iam.securityAdmin` - To manage IAM policies and role bindings
+4. `roles/compute.networkAdmin` - To create and manage network resources
+5. `roles/compute.securityAdmin` - To create and manage firewall rules
+6. `roles/compute.loadBalancerAdmin` - To manage load balancers, backend services, and health checks
+7. `roles/iap.admin` - To configure Identity-Aware Proxy
+8. `roles/dns.admin` - To manage DNS records if needed
+9. `roles/serviceusage.serviceUsageAdmin` - To enable required APIs
 
 You can grant these roles to your account with:
 
@@ -76,6 +80,10 @@ gcloud projects add-iam-policy-binding data-project-example \
 
 gcloud projects add-iam-policy-binding data-project-example \
   --member=user:YOUR_EMAIL \
+  --role=roles/iam.securityAdmin
+
+gcloud projects add-iam-policy-binding data-project-example \
+  --member=user:YOUR_EMAIL \
   --role=roles/compute.networkAdmin
 
 gcloud projects add-iam-policy-binding data-project-example \
@@ -84,7 +92,19 @@ gcloud projects add-iam-policy-binding data-project-example \
 
 gcloud projects add-iam-policy-binding data-project-example \
   --member=user:YOUR_EMAIL \
+  --role=roles/compute.loadBalancerAdmin
+
+gcloud projects add-iam-policy-binding data-project-example \
+  --member=user:YOUR_EMAIL \
   --role=roles/iap.admin
+
+gcloud projects add-iam-policy-binding data-project-example \
+  --member=user:YOUR_EMAIL \
+  --role=roles/dns.admin
+
+gcloud projects add-iam-policy-binding data-project-example \
+  --member=user:YOUR_EMAIL \
+  --role=roles/serviceusage.serviceUsageAdmin
 ```
 
 Replace `YOUR_EMAIL` with your Google Cloud account email.
@@ -94,25 +114,21 @@ Replace `YOUR_EMAIL` with your Google Cloud account email.
 If you're using Terraform Cloud, make sure the service account has the necessary permissions:
 
 ```bash
-gcloud projects add-iam-policy-binding data-project-example \
-  --member=serviceAccount:TERRAFORM_CLOUD_SA_EMAIL \
-  --role=roles/iam.workloadIdentityPoolAdmin
-
-gcloud projects add-iam-policy-binding data-project-example \
-  --member=serviceAccount:TERRAFORM_CLOUD_SA_EMAIL \
-  --role=roles/iam.serviceAccountAdmin
-
-gcloud projects add-iam-policy-binding data-project-example \
-  --member=serviceAccount:TERRAFORM_CLOUD_SA_EMAIL \
-  --role=roles/compute.networkAdmin
-
-gcloud projects add-iam-policy-binding data-project-example \
-  --member=serviceAccount:TERRAFORM_CLOUD_SA_EMAIL \
-  --role=roles/compute.securityAdmin
-
-gcloud projects add-iam-policy-binding data-project-example \
-  --member=serviceAccount:TERRAFORM_CLOUD_SA_EMAIL \
-  --role=roles/iap.admin
+for ROLE in \
+  roles/iam.workloadIdentityPoolAdmin \
+  roles/iam.serviceAccountAdmin \
+  roles/iam.securityAdmin \
+  roles/compute.networkAdmin \
+  roles/compute.securityAdmin \
+  roles/compute.loadBalancerAdmin \
+  roles/iap.admin \
+  roles/dns.admin \
+  roles/serviceusage.serviceUsageAdmin
+do
+  gcloud projects add-iam-policy-binding data-project-example \
+    --member=serviceAccount:TERRAFORM_CLOUD_SA_EMAIL \
+    --role=$ROLE
+done
 ```
 
 Replace `TERRAFORM_CLOUD_SA_EMAIL` with the email of the service account used by Terraform Cloud.


### PR DESCRIPTION
This pull request includes updates to the documentation for setting up IAM policies and access roles for the Terraform service account used in the networking module. The changes primarily focus on expanding the required roles and providing detailed instructions for applying these policies.

Documentation updates:

* [`infrastructure/networking/README.md`](diffhunk://#diff-d16d5e4c504611746c6074741346978561eb19b2c8f48453dab29eef5ce9c1e1R626-R675): Added a new section detailing the required IAM policies for the Terraform service account, including a table of roles and their purposes, and instructions for applying these policies using `gcloud` commands.
* [`infrastructure/networking/setup.md`](diffhunk://#diff-445f23b41bbb29c1f74bda8553ed387d77357c146c1f3e7de35c0ba3254a25b7L62-R68): Updated the list of required IAM roles for the Terraform service account, adding new roles and reordering existing ones for clarity. Included a script to apply these roles using `gcloud` commands. [[1]](diffhunk://#diff-445f23b41bbb29c1f74bda8553ed387d77357c146c1f3e7de35c0ba3254a25b7L62-R68) [[2]](diffhunk://#diff-445f23b41bbb29c1f74bda8553ed387d77357c146c1f3e7de35c0ba3254a25b7R81-R84) [[3]](diffhunk://#diff-445f23b41bbb29c1f74bda8553ed387d77357c146c1f3e7de35c0ba3254a25b7R93-R107) [[4]](diffhunk://#diff-445f23b41bbb29c1f74bda8553ed387d77357c146c1f3e7de35c0ba3254a25b7R117-R131)